### PR TITLE
Ensure /usr/local/bin exists

### DIFF
--- a/liftoff.sh
+++ b/liftoff.sh
@@ -113,6 +113,12 @@ define_actions() {
     # https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
     install_composer() {
         title "2. Install Composer"
+        
+        if [ ! -d "$BIN" ]; then
+            echo "   Creating /usr/local/bin for your. This required your password."
+            sudo mkdir -p $BIN
+            sudo chown -R $(whoami) $BIN
+        fi
 
         if command_exists composer; then
             echo "   Composer already installed; skipping."


### PR DESCRIPTION
This PR fixes #8 
Before installing composer, we will check if /usr/local/bin actually exists and create it otherwise.