### PR TITLE
Append composer vendor bin direcory to PATH in shell profile

### DIFF
--- a/liftoff.sh
+++ b/liftoff.sh
@@ -39,6 +39,26 @@ define_helpers() {
         php -v | grep ^PHP | cut -d' ' -f2
     }
 
+    preferred_shell() {
+        local shellName="$(basename $SHELL)"
+        echo "$shellName" | sed -e 's/-.*//g'
+    }
+
+    shell_profile() {
+        local preferredShell=$(preferred_shell)
+
+        case $preferredShell in
+            bash) echo "$HOME/.bash_profile" ;;
+            zsh) echo "$HOME/.zshrc" ;;
+            sh) echo "$HOME/.profile" ;;
+            *) echo "~/.profile" ;;
+        esac
+    }
+
+    prepend_path_in_profile() {
+        echo "export PATH=\"$@:\$PATH\"" >> $(shell_profile)
+    }
+
     php_version_is_acceptable() {
         php -r 'exit((int)version_compare(PHP_VERSION, "7.0.0", "<"));'
     }
@@ -151,6 +171,9 @@ define_actions() {
             mv composer.phar $TARGET_PATH
 
             if [ $RESULT ]; then
+                local COMPOSER_BIN_PATH="$HOME/.composer/vendor/bin"
+                prepend_path_in_profile $COMPOSER_BIN_PATH
+
                 echo "   Composer installed!"
             else
                 echo "   Error installing Composer."


### PR DESCRIPTION
This PR fixes #11 by prepending the composer vendor bin path to the users $PATH variable and add it to the correct shell source file.

I took some inspiration from [brew](https://github.com/Homebrew/brew/blob/bf7fe45e8998e56e6690347a0192c454b8cb203b/Library/Homebrew/utils/shell.rb#L74)

What's still missing, is that after the installation, the PATH variable gets exported immediately, so users can run `laravel new` right away.